### PR TITLE
PHP loader: use phpstan `includes`

### DIFF
--- a/src/Handler/PhpBaselineHandler.php
+++ b/src/Handler/PhpBaselineHandler.php
@@ -55,13 +55,13 @@ class PhpBaselineHandler implements BaselineHandler
     public function encodeBaselineLoader(array $filePaths, string $indent): string
     {
         $php = "<?php declare(strict_types = 1);\n\n";
-        $php .= "return array_merge_recursive(\n";
+        $php .= "return ['includes' => [\n";
 
         foreach ($filePaths as $filePath) {
-            $php .= "{$indent}require __DIR__ . '/$filePath',\n";
+            $php .= "{$indent}__DIR__ . '/$filePath',\n";
         }
 
-        $php .= ");\n";
+        $php .= "]];\n";
 
         return $php;
     }

--- a/tests/Rule/data/baselines-php/loader.php
+++ b/tests/Rule/data/baselines-php/loader.php
@@ -1,7 +1,7 @@
 <?php declare(strict_types = 1);
 
-return array_merge_recursive(
-    require __DIR__ . '/another.identifier.php',
-    require __DIR__ . '/missing-identifier.php',
-    require __DIR__ . '/sample.identifier.php',
-);
+return ['includes' => [
+    __DIR__ . '/another.identifier.php',
+    __DIR__ . '/missing-identifier.php',
+    __DIR__ . '/sample.identifier.php',
+]];


### PR DESCRIPTION
Using phpstan `includes` instead of `require` improves the cache handling. 

At the moment phpstan does not recognize changes in the baseline files (e.g. when removing/comment a baseline entry manually). It only recognizes changes to the loader file.