### PR TITLE
Add the total error count in the loader

### DIFF
--- a/src/BaselinePerIdentifierFormatter.php
+++ b/src/BaselinePerIdentifierFormatter.php
@@ -70,6 +70,7 @@ class BaselinePerIdentifierFormatter implements ErrorFormatter
         ksort($fileErrors, SORT_STRING);
 
         $includes = [];
+        $totalErrorsCount = 0;
 
         foreach ($fileErrors as $identifier => $errors) {
             $errorsToOutput = [];
@@ -102,6 +103,7 @@ class BaselinePerIdentifierFormatter implements ErrorFormatter
             $includes[] = $identifier . '.neon';
             $baselineFilePath = $this->baselinesDir . '/' . $identifier . '.neon';
 
+            $totalErrorsCount += $errorsCount;
             $output->writeLineFormatted(sprintf('Writing baseline file %s with %d errors', $baselineFilePath, $errorsCount));
 
             $plurality = $errorsCount === 1 ? '' : 's';
@@ -114,7 +116,9 @@ class BaselinePerIdentifierFormatter implements ErrorFormatter
             }
         }
 
-        $writtenLoader = file_put_contents($this->baselinesDir . '/loader.neon', NeonHelper::encode(['includes' => $includes], $this->indent));
+        $plurality = $totalErrorsCount === 1 ? '' : 's';
+        $prefix = "# total $totalErrorsCount error$plurality\n";
+        $writtenLoader = file_put_contents($this->baselinesDir . '/loader.neon', $prefix . NeonHelper::encode(['includes' => $includes], $this->indent));
 
         if ($writtenLoader === false) {
             throw new LogicException('Error while writing to ' . $this->baselinesDir . '/loader.neon');

--- a/src/BaselineSplitter.php
+++ b/src/BaselineSplitter.php
@@ -58,11 +58,13 @@ class BaselineSplitter
 
         $outputInfo = [];
         $baselineFiles = [];
+        $totalErrorCount = 0;
 
         foreach ($groupedErrors as $identifier => $errors) {
             $fileName = $identifier . '.' . $extension;
             $filePath = $folder . '/' . $fileName;
             $errorsCount = array_reduce($errors, static fn(int $carry, array $item): int => $carry + $item['count'], 0);
+            $totalErrorCount += $errorsCount;
 
             $outputInfo[$filePath] = $errorsCount;
             $baselineFiles[] = $fileName;
@@ -74,7 +76,9 @@ class BaselineSplitter
             $this->writeFile($filePath, $encodedData);
         }
 
-        $baselineLoaderData = $handler->encodeBaselineLoader($baselineFiles, $this->indent);
+        $plural = $totalErrorCount === 1 ? '' : 's';
+        $prefix = "total $totalErrorCount error$plural";
+        $baselineLoaderData = $handler->encodeBaselineLoader($prefix, $baselineFiles, $this->indent);
         $this->writeFile($realPath, $baselineLoaderData);
 
         $outputInfo[$realPath] = null;

--- a/src/Handler/BaselineHandler.php
+++ b/src/Handler/BaselineHandler.php
@@ -21,6 +21,6 @@ interface BaselineHandler
     /**
      * @param list<string> $filePaths
      */
-    public function encodeBaselineLoader(array $filePaths, string $indent): string;
+    public function encodeBaselineLoader(string $comment, array $filePaths, string $indent): string;
 
 }

--- a/src/Handler/NeonBaselineHandler.php
+++ b/src/Handler/NeonBaselineHandler.php
@@ -35,9 +35,10 @@ class NeonBaselineHandler implements BaselineHandler
         return $prefix . NeonHelper::encode(['parameters' => ['ignoreErrors' => $errors]], $indent);
     }
 
-    public function encodeBaselineLoader(array $filePaths, string $indent): string
+    public function encodeBaselineLoader(string $comment, array $filePaths, string $indent): string
     {
-        return NeonHelper::encode(['includes' => $filePaths], $indent);
+        $prefix = "# $comment\n";
+        return $prefix . NeonHelper::encode(['includes' => $filePaths], $indent);
     }
 
 }

--- a/src/Handler/PhpBaselineHandler.php
+++ b/src/Handler/PhpBaselineHandler.php
@@ -52,9 +52,10 @@ class PhpBaselineHandler implements BaselineHandler
         return $php;
     }
 
-    public function encodeBaselineLoader(array $filePaths, string $indent): string
+    public function encodeBaselineLoader(string $comment, array $filePaths, string $indent): string
     {
         $php = "<?php declare(strict_types = 1);\n\n";
+        $php .= "// $comment\n";
         $php .= "return ['includes' => [\n";
 
         foreach ($filePaths as $filePath) {

--- a/tests/Rule/data/baselines-neon/loader.neon
+++ b/tests/Rule/data/baselines-neon/loader.neon
@@ -1,3 +1,4 @@
+# total 4 errors
 includes:
     - another.identifier.neon
     - missing-identifier.neon

--- a/tests/Rule/data/baselines-php/loader.php
+++ b/tests/Rule/data/baselines-php/loader.php
@@ -1,5 +1,6 @@
 <?php declare(strict_types = 1);
 
+// total 4 errors
 return ['includes' => [
     __DIR__ . '/another.identifier.php',
     __DIR__ . '/missing-identifier.php',


### PR DESCRIPTION
Currently there is no way on knowing the total number of error except by summing all files. This PR adds a the total in the loader file.

example:
```php
<?php declare(strict_types = 1);

// total 4 errors
return ['includes' => [
    __DIR__ . '/another.identifier.php',
    __DIR__ . '/missing-identifier.php',
    __DIR__ . '/sample.identifier.php',
]];
```



\cc @janedbal 