### PR TITLE
fix tests for macOS

### DIFF
--- a/tests/Rule/BaselinePerIdentifierFormatterTest.php
+++ b/tests/Rule/BaselinePerIdentifierFormatterTest.php
@@ -7,6 +7,7 @@ use PHPStan\Command\AnalysisResult;
 use PHPStan\Command\Output;
 use PHPStan\Testing\PHPStanTestCase;
 use function mkdir;
+use function realpath;
 use function sys_get_temp_dir;
 use function uniqid;
 
@@ -15,7 +16,7 @@ final class BaselinePerIdentifierFormatterTest extends PHPStanTestCase
 
     public function testFormat(): void
     {
-        $fakeRoot = sys_get_temp_dir() . '/' . uniqid('root');
+        $fakeRoot = realpath(sys_get_temp_dir()) . '/' . uniqid('root');
         @mkdir($fakeRoot . '/baselines', 0777, true);
 
         $formatter = new BaselinePerIdentifierFormatter($fakeRoot . '/baselines', '    ');

--- a/tests/Rule/BaselinePerIdentifierFormatterTest.php
+++ b/tests/Rule/BaselinePerIdentifierFormatterTest.php
@@ -16,7 +16,10 @@ final class BaselinePerIdentifierFormatterTest extends PHPStanTestCase
 
     public function testFormat(): void
     {
-        $fakeRoot = realpath(sys_get_temp_dir()) . '/' . uniqid('root');
+        $fakeRoot = realpath(sys_get_temp_dir());
+        self::assertNotFalse($fakeRoot);
+
+        $fakeRoot = $fakeRoot . '/' . uniqid('root');
         @mkdir($fakeRoot . '/baselines', 0777, true);
 
         $formatter = new BaselinePerIdentifierFormatter($fakeRoot . '/baselines', '    ');

--- a/tests/SplitterTest.php
+++ b/tests/SplitterTest.php
@@ -94,7 +94,10 @@ final class SplitterTest extends BinTestCase
 
     private function prepareSampleFolder(): string
     {
-        $folder = realpath(sys_get_temp_dir()) . '/' . uniqid('split');
+        $folder = realpath(sys_get_temp_dir());
+        self::assertNotFalse($folder);
+
+        $folder = $folder . '/' . uniqid('split');
         @mkdir($folder . '/baselines', 0777, true);
 
         return $folder;

--- a/tests/SplitterTest.php
+++ b/tests/SplitterTest.php
@@ -5,6 +5,7 @@ namespace ShipMonk\PHPStan\Baseline;
 use Nette\Neon\Neon;
 use function file_put_contents;
 use function mkdir;
+use function realpath;
 use function sys_get_temp_dir;
 use function uniqid;
 use function var_export;
@@ -93,7 +94,7 @@ final class SplitterTest extends BinTestCase
 
     private function prepareSampleFolder(): string
     {
-        $folder = sys_get_temp_dir() . '/' . uniqid('split');
+        $folder = realpath(sys_get_temp_dir()) . '/' . uniqid('split');
         @mkdir($folder . '/baselines', 0777, true);
 
         return $folder;


### PR DESCRIPTION
When I run the unit tests on my mac (homebrew setup), I always get errors:

<img width="837" height="617" alt="Bildschirmfoto 2025-07-15 um 19 47 12" src="https://github.com/user-attachments/assets/98390878-d3ec-4970-b30f-612c1b6b566e" />

Using the realpath of the `sys_get_temp_dir()` fixes it.