### PR TITLE
New loader filename suggestion: `_loader.neon`

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Split your [PHPStan baseline](https://phpstan.org/user-guide/baseline) into mult
 
 ```txt
 baselines/
- ├─ loader.neon
+ ├─ _loader.neon
  ├─ empty.notAllowed.neon
  ├─ foreach.nonIterable.neon
  ├─ identical.alwaysFalse.neon
@@ -43,14 +43,14 @@ Remove old single baseline include:
 
 Run native baseline generation and split it into multiple files via our script (other baseline files will be placed beside the loader):
 ```sh
-vendor/bin/phpstan --generate-baseline=baselines/loader.neon && vendor/bin/split-phpstan-baseline baselines/loader.neon
+vendor/bin/phpstan --generate-baseline=baselines/_loader.neon && vendor/bin/split-phpstan-baseline baselines/_loader.neon
 ```
 
 Setup the baselines loader:
 ```neon
 # phpstan.neon.dist
 includes:
-    - baselines/loader.neon
+    - baselines/_loader.neon
 ```
 
 _(optional)_ You can simplify generation with e.g. composer script:
@@ -58,9 +58,9 @@ _(optional)_ You can simplify generation with e.g. composer script:
 {
     "scripts": {
         "generate:baseline:phpstan": [
-            "phpstan --generate-baseline=baselines/loader.neon",
-            "find baselines/ -type f -not -name loader.neon -delete",
-            "split-phpstan-baseline baselines/loader.neon"
+            "phpstan --generate-baseline=baselines/_loader.neon",
+            "find baselines/ -type f -not -name _loader.neon -delete",
+            "split-phpstan-baseline baselines/_loader.neon"
         ]
     }
 }

--- a/bin/split-phpstan-baseline
+++ b/bin/split-phpstan-baseline
@@ -38,7 +38,7 @@ $includeCount = !(isset($providedOptions['no-error-count']) || in_array('--no-er
 if ($loaderFile === null) {
     error(
         "Missing argument. Usage:\n".
-        " vendor/bin/phpstan --generate-baseline=baselines/loader.neon && vendor/bin/split-phpstan-baseline baselines/loader.neon"
+        " vendor/bin/phpstan --generate-baseline=baselines/_loader.neon && vendor/bin/split-phpstan-baseline baselines/_loader.neon"
     );
 }
 

--- a/tests/Integration/IntegrationTest.php
+++ b/tests/Integration/IntegrationTest.php
@@ -28,15 +28,15 @@ final class IntegrationTest extends BinTestCase
         array_map('unlink', glob($baselinesDirAbs . '/*')); // @phpstan-ignore argument.type
 
         // ensure dummy loader is present
-        file_put_contents($baselinesDirAbs . "/loader.$extension", $emptyConfig);
+        file_put_contents($baselinesDirAbs . "/_loader.$extension", $emptyConfig);
 
         $cwd = __DIR__;
         $phpstan = '../../vendor/bin/phpstan';
         $split = '../../bin/split-phpstan-baseline';
 
         $this->runCommand("$phpstan clear-result-cache -c $extension.neon", $cwd, 0);
-        $this->runCommand("$phpstan analyse -vv -c $extension.neon --generate-baseline=../../$baselinesDir/loader.$extension", $cwd, 0, null, 'Result cache is saved.');
-        $this->runCommand("php $split ../../$baselinesDir/loader.$extension", $cwd, 0, 'Writing baseline file');
+        $this->runCommand("$phpstan analyse -vv -c $extension.neon --generate-baseline=../../$baselinesDir/_loader.$extension", $cwd, 0, null, 'Result cache is saved.');
+        $this->runCommand("php $split ../../$baselinesDir/_loader.$extension", $cwd, 0, 'Writing baseline file');
         $this->runCommand("$phpstan analyse -vv -c $extension.neon", $cwd, 0, null, 'Result cache restored. 0 files will be reanalysed.');
 
         // cache should invalidate by editing the baseline

--- a/tests/Integration/neon.neon
+++ b/tests/Integration/neon.neon
@@ -5,4 +5,4 @@ parameters:
         - src
 
 includes:
-    - ../../cache/integration-test/baselines/loader.neon
+    - ../../cache/integration-test/baselines/_loader.neon

--- a/tests/Integration/php.neon
+++ b/tests/Integration/php.neon
@@ -5,4 +5,4 @@ parameters:
         - src
 
 includes:
-    - ../../cache/integration-test/baselines/loader.php
+    - ../../cache/integration-test/baselines/_loader.php


### PR DESCRIPTION
The loader file name can be chosen freely. I always use `_loader.php`, because I like to have it at the top in the baseline directory.

I suggest using this as a general recommendation.

Of course, it is still possible to continue using `loader.ext`.

