### PR TITLE
Add minimal diff support when regenerating baseline files

### DIFF
--- a/src/BaselineSplitter.php
+++ b/src/BaselineSplitter.php
@@ -10,6 +10,7 @@ use SplFileInfo;
 use function array_reduce;
 use function dirname;
 use function file_put_contents;
+use function is_file;
 use function ksort;
 use function str_replace;
 
@@ -156,6 +157,10 @@ class BaselineSplitter
         BaselineHandler $handler
     ): ?array
     {
+        if (!is_file($filePath)) {
+            return null;
+        }
+
         try {
             return $handler->decodeBaseline($filePath);
 

--- a/src/BaselineSplitter.php
+++ b/src/BaselineSplitter.php
@@ -3,15 +3,13 @@
 namespace ShipMonk\PHPStan\Baseline;
 
 use ShipMonk\PHPStan\Baseline\Exception\ErrorException;
+use ShipMonk\PHPStan\Baseline\Handler\BaselineHandler;
 use ShipMonk\PHPStan\Baseline\Handler\HandlerFactory;
 use SplFileInfo;
 use function array_reduce;
-use function assert;
+use function array_splice;
 use function dirname;
 use function file_put_contents;
-use function is_array;
-use function is_int;
-use function is_string;
 use function ksort;
 use function str_replace;
 
@@ -49,28 +47,21 @@ class BaselineSplitter
         $extension = $splFile->getExtension();
 
         $handler = HandlerFactory::create($extension);
-        $data = $handler->decodeBaseline($realPath);
-
-        $ignoredErrors = $data['parameters']['ignoreErrors'] ?? null; // @phpstan-ignore offsetAccess.nonOffsetAccessible
-
-        if (!is_array($ignoredErrors)) {
-            throw new ErrorException(
-                "Invalid argument, expected $extension file with 'parameters.ignoreErrors' key in '$loaderFilePath'." .
-                "\n - Did you run native baseline generation first?" .
-                "\n - You can so via vendor/bin/phpstan --generate-baseline=$loaderFilePath",
-            );
-        }
-
+        $ignoredErrors = $handler->decodeBaseline($realPath);
         $groupedErrors = $this->groupErrorsByIdentifier($ignoredErrors, $folder);
 
         $outputInfo = [];
         $baselineFiles = [];
         $totalErrorCount = 0;
 
-        foreach ($groupedErrors as $identifier => $errors) {
+        foreach ($groupedErrors as $identifier => $newErrors) {
             $fileName = $identifier . '.' . $extension;
             $filePath = $folder . '/' . $fileName;
-            $errorsCount = array_reduce($errors, static fn (int $carry, array $item): int => $carry + $item['count'], 0);
+
+            $oldErrors = $this->readExistingErrors($filePath, $handler) ?? [];
+            $sortedErrors = $this->sortErrors($oldErrors, $newErrors);
+
+            $errorsCount = array_reduce($sortedErrors, static fn (int $carry, array $item): int => $carry + $item['count'], 0);
             $totalErrorCount += $errorsCount;
 
             $outputInfo[$filePath] = $errorsCount;
@@ -79,7 +70,7 @@ class BaselineSplitter
             $plural = $errorsCount === 1 ? '' : 's';
             $prefix = $this->includeCount ? "total $errorsCount error$plural" : null;
 
-            $encodedData = $handler->encodeBaseline($prefix, $errors, $this->indent);
+            $encodedData = $handler->encodeBaseline($prefix, $sortedErrors, $this->indent);
             $this->writeFile($filePath, $encodedData);
         }
 
@@ -94,7 +85,7 @@ class BaselineSplitter
     }
 
     /**
-     * @param array<mixed> $errors
+     * @param list<array{message: string, count: int, path: string, identifier: string|null}|array{rawMessage: string, count: int, path: string, identifier: string|null}> $errors
      * @return array<string, list<array{message: string, count: int, path: string}|array{rawMessage: string, count: int, path: string}>>
      *
      * @throws ErrorException
@@ -106,53 +97,27 @@ class BaselineSplitter
     {
         $groupedErrors = [];
 
-        foreach ($errors as $index => $error) {
-            if (!is_array($error)) {
-                throw new ErrorException("Ignored error #$index is not an array");
-            }
-
+        foreach ($errors as $error) {
             $identifier = $error['identifier'] ?? 'missing-identifier';
+            $normalizedPath = str_replace($folder . '/', '', $error['path']);
 
             if (isset($error['rawMessage'])) {
-                $message = $error['rawMessage'];
-                $rawMessage = true;
+                $groupedErrors[$identifier][] = [
+                    'rawMessage' => $error['rawMessage'],
+                    'count' => $error['count'],
+                    'path' => $normalizedPath,
+                ];
+
             } elseif (isset($error['message'])) {
-                $message = $error['message'];
-                $rawMessage = false;
+                $groupedErrors[$identifier][] = [
+                    'message' => $error['message'],
+                    'count' => $error['count'],
+                    'path' => $normalizedPath,
+                ];
+
             } else {
-                throw new ErrorException("Ignored error #$index is missing 'message' or 'rawMessage'");
+                throw new ErrorException('Error is missing message or rawMessage');
             }
-
-            if (!isset($error['count'])) {
-                throw new ErrorException("Ignored error #$index is missing 'count'");
-            }
-
-            $count = $error['count'];
-
-            if (!isset($error['path'])) {
-                throw new ErrorException("Ignored error #$index is missing 'path'");
-            }
-
-            $path = $error['path'];
-
-            assert(is_string($identifier));
-            assert(is_string($message));
-            assert(is_int($count));
-            assert(is_string($path));
-
-            $normalizedPath = str_replace($folder . '/', '', $path);
-
-            unset($error['identifier']);
-
-            $groupedErrors[$identifier][] = $rawMessage ? [
-                'rawMessage' => $message,
-                'count' => $count,
-                'path' => $normalizedPath,
-            ] : [
-                'message' => $message,
-                'count' => $count,
-                'path' => $normalizedPath,
-            ];
         }
 
         ksort($groupedErrors);
@@ -173,6 +138,72 @@ class BaselineSplitter
         if ($written === false) {
             throw new ErrorException('Error while writing to ' . $filePath);
         }
+    }
+
+    /**
+     * @param array{message?: string, rawMessage?: string, count: int, path: string} $error
+     * @return array{string, string}
+     */
+    private function getErrorKey(array $error): array
+    {
+        return [
+            $error['path'],
+            $error['rawMessage'] ?? $error['message'] ?? '',
+        ];
+    }
+
+    /**
+     * @return list<array{message: string, count: int, path: string}|array{rawMessage: string, count: int, path: string}>|null
+     */
+    private function readExistingErrors(
+        string $filePath,
+        BaselineHandler $handler
+    ): ?array
+    {
+        try {
+            return $handler->decodeBaseline($filePath);
+
+        } catch (ErrorException $e) {
+            return null;
+        }
+    }
+
+    /**
+     * @param list<array{message: string, count: int, path: string}|array{rawMessage: string, count: int, path: string}> $oldErrors
+     * @param list<array{message: string, count: int, path: string}|array{rawMessage: string, count: int, path: string}> $newErrors
+     * @return list<array{message: string, count: int, path: string}|array{rawMessage: string, count: int, path: string}>
+     */
+    private function sortErrors(
+        array $oldErrors,
+        array $newErrors
+    ): array
+    {
+        $sortedErrors = [];
+
+        // insert existing errors in the original order
+        foreach ($oldErrors as $oldError) {
+            foreach ($newErrors as $key => $newError) {
+                if ($this->getErrorKey($oldError) === $this->getErrorKey($newError)) {
+                    $sortedErrors[] = $newError;
+                    unset($newErrors[$key]);
+                    break;
+                }
+            }
+        }
+
+        // insert remaining errors
+        foreach ($newErrors as $newError) {
+            foreach ($sortedErrors as $key => $sortedError) {
+                if ($this->getErrorKey($newError) < $this->getErrorKey($sortedError)) {
+                    array_splice($sortedErrors, $key, 0, [$newError]);
+                    continue 2;
+                }
+            }
+
+            $sortedErrors[] = $newError;
+        }
+
+        return $sortedErrors;
     }
 
 }

--- a/src/BaselineSplitter.php
+++ b/src/BaselineSplitter.php
@@ -2,12 +2,12 @@
 
 namespace ShipMonk\PHPStan\Baseline;
 
+use ArrayIterator;
 use ShipMonk\PHPStan\Baseline\Exception\ErrorException;
 use ShipMonk\PHPStan\Baseline\Handler\BaselineHandler;
 use ShipMonk\PHPStan\Baseline\Handler\HandlerFactory;
 use SplFileInfo;
 use function array_reduce;
-use function array_splice;
 use function dirname;
 use function file_put_contents;
 use function ksort;
@@ -142,14 +142,10 @@ class BaselineSplitter
 
     /**
      * @param array{message?: string, rawMessage?: string, count: int, path: string} $error
-     * @return array{string, string}
      */
-    private function getErrorKey(array $error): array
+    private function getErrorKey(array $error): string
     {
-        return [
-            $error['path'],
-            $error['rawMessage'] ?? $error['message'] ?? '',
-        ];
+        return $error['path'] . "\x00" . ($error['rawMessage'] ?? $error['message'] ?? '');
     }
 
     /**
@@ -178,32 +174,45 @@ class BaselineSplitter
         array $newErrors
     ): array
     {
-        $sortedErrors = [];
+        $newErrorsByKey = [];
 
-        // insert existing errors in the original order
-        foreach ($oldErrors as $oldError) {
-            foreach ($newErrors as $key => $newError) {
-                if ($this->getErrorKey($oldError) === $this->getErrorKey($newError)) {
-                    $sortedErrors[] = $newError;
-                    unset($newErrors[$key]);
-                    break;
-                }
-            }
-        }
-
-        // insert remaining errors
         foreach ($newErrors as $newError) {
-            foreach ($sortedErrors as $key => $sortedError) {
-                if ($this->getErrorKey($newError) < $this->getErrorKey($sortedError)) {
-                    array_splice($sortedErrors, $key, 0, [$newError]);
-                    continue 2;
-                }
-            }
-
-            $sortedErrors[] = $newError;
+            $key = $this->getErrorKey($newError);
+            $newErrorsByKey[$key] = $newError;
         }
 
-        return $sortedErrors;
+        // collect errors that existed before
+        $existingByKey = [];
+
+        foreach ($oldErrors as $oldError) {
+            $key = $this->getErrorKey($oldError);
+
+            if (isset($newErrorsByKey[$key])) {
+                $existingByKey[$key] = $newErrorsByKey[$key];
+                unset($newErrorsByKey[$key]);
+            }
+        }
+
+        // insert new errors at their sorted positions among existing errors
+        ksort($newErrorsByKey);
+        $newErrorsIterator = new ArrayIterator($newErrorsByKey);
+        $result = [];
+
+        foreach ($existingByKey as $existingKey => $existingError) {
+            while ($newErrorsIterator->valid() && $newErrorsIterator->key() < $existingKey) {
+                $result[] = $newErrorsIterator->current();
+                $newErrorsIterator->next();
+            }
+
+            $result[] = $existingError;
+        }
+
+        while ($newErrorsIterator->valid()) {
+            $result[] = $newErrorsIterator->current();
+            $newErrorsIterator->next();
+        }
+
+        return $result;
     }
 
 }

--- a/src/Handler/BaselineHandler.php
+++ b/src/Handler/BaselineHandler.php
@@ -3,21 +3,95 @@
 namespace ShipMonk\PHPStan\Baseline\Handler;
 
 use ShipMonk\PHPStan\Baseline\Exception\ErrorException;
+use function is_array;
+use function is_int;
+use function is_string;
 
-interface BaselineHandler
+abstract class BaselineHandler
 {
+
+    /**
+     * @return list<array{message: string, count: int, path: string, identifier: string|null}|array{rawMessage: string, count: int, path: string, identifier: string|null}>
+     *
+     * @throws ErrorException
+     */
+    public function decodeBaseline(string $filepath): array
+    {
+        $decoded = $this->decodeBaselineFile($filepath);
+
+        if (!isset($decoded['parameters']) || !is_array($decoded['parameters'])) {
+            throw new ErrorException("File '$filepath' must contain 'parameters' array");
+        }
+
+        if (!isset($decoded['parameters']['ignoreErrors']) || !is_array($decoded['parameters']['ignoreErrors'])) {
+            throw new ErrorException("File '$filepath' must contain 'parameters.ignoreErrors' array");
+        }
+
+        $errors = $decoded['parameters']['ignoreErrors'];
+        $result = [];
+
+        foreach ($errors as $index => $error) {
+            if (!is_array($error)) {
+                throw new ErrorException("Ignored error #$index in '$filepath' is not an array");
+            }
+
+            if (!isset($error['path']) || !is_string($error['path'])) {
+                throw new ErrorException("Ignored error #$index in '$filepath' is missing 'path'");
+            }
+
+            if (!isset($error['count']) || !is_int($error['count'])) {
+                throw new ErrorException("Ignored error #$index in '$filepath' is missing 'count'");
+            }
+
+            $error['identifier'] ??= null;
+
+            if ($error['identifier'] !== null && !is_string($error['identifier'])) {
+                throw new ErrorException("Ignored error #$index in '$filepath' has invalid 'identifier'");
+            }
+
+            if (isset($error['rawMessage'])) {
+                if (!is_string($error['rawMessage'])) {
+                    throw new ErrorException("Ignored error #$index in '$filepath' has invalid 'rawMessage'");
+                }
+
+                $result[] = [
+                    'rawMessage' => $error['rawMessage'],
+                    'count' => $error['count'],
+                    'path' => $error['path'],
+                    'identifier' => $error['identifier'],
+                ];
+
+            } elseif (isset($error['message'])) {
+                if (!is_string($error['message'])) {
+                    throw new ErrorException("Ignored error #$index in '$filepath' has invalid 'message'");
+                }
+
+                $result[] = [
+                    'message' => $error['message'],
+                    'count' => $error['count'],
+                    'path' => $error['path'],
+                    'identifier' => $error['identifier'],
+                ];
+
+            } else {
+                throw new ErrorException("Ignored error #$index in '$filepath' is missing 'message' or 'rawMessage'");
+            }
+        }
+
+        return $result;
+    }
 
     /**
      * @return array<mixed>
      *
      * @throws ErrorException
      */
-    public function decodeBaseline(string $filepath): array;
+    abstract protected function decodeBaselineFile(string $filepath): array;
 
     /**
      * @param list<array{message: string, count: int, path: string}|array{rawMessage: string, count: int, path: string}> $errors
      */
-    public function encodeBaseline(
+    abstract public function encodeBaseline(
         ?string $comment,
         array $errors,
         string $indent
@@ -26,7 +100,7 @@ interface BaselineHandler
     /**
      * @param list<string> $filePaths
      */
-    public function encodeBaselineLoader(
+    abstract public function encodeBaselineLoader(
         ?string $comment,
         array $filePaths,
         string $indent

--- a/src/Handler/NeonBaselineHandler.php
+++ b/src/Handler/NeonBaselineHandler.php
@@ -9,10 +9,10 @@ use ShipMonk\PHPStan\Baseline\NeonHelper;
 use function gettype;
 use function is_array;
 
-class NeonBaselineHandler implements BaselineHandler
+class NeonBaselineHandler extends BaselineHandler
 {
 
-    public function decodeBaseline(string $filepath): array
+    protected function decodeBaselineFile(string $filepath): array
     {
         try {
             /** @throws NeonException */

--- a/src/Handler/PhpBaselineHandler.php
+++ b/src/Handler/PhpBaselineHandler.php
@@ -9,10 +9,10 @@ use function is_array;
 use function sprintf;
 use function var_export;
 
-class PhpBaselineHandler implements BaselineHandler
+class PhpBaselineHandler extends BaselineHandler
 {
 
-    public function decodeBaseline(string $filepath): array
+    protected function decodeBaselineFile(string $filepath): array
     {
         try {
             $decoded = (static fn () => require $filepath)();
@@ -23,8 +23,10 @@ class PhpBaselineHandler implements BaselineHandler
 
             return $decoded;
 
+        } catch (ErrorException $e) {
+            throw $e;
         } catch (Throwable $e) {
-            throw new ErrorException("Error while loading baseline file '$filepath':" . $e->getMessage(), $e);
+            throw new ErrorException("Error while loading baseline file '$filepath': " . $e->getMessage(), $e);
         }
     }
 

--- a/tests/SplitterTest.php
+++ b/tests/SplitterTest.php
@@ -3,9 +3,11 @@
 namespace ShipMonk\PHPStan\Baseline;
 
 use Nette\Neon\Neon;
+use function file_get_contents;
 use function file_put_contents;
 use function mkdir;
 use function realpath;
+use function strpos;
 use function sys_get_temp_dir;
 use function uniqid;
 use function var_export;
@@ -101,6 +103,235 @@ final class SplitterTest extends BinTestCase
         @mkdir($folder . '/baselines', 0777, true);
 
         return $folder;
+    }
+
+    public function testPreservesOrderOfExistingErrors(): void
+    {
+        $folder = $this->prepareSampleFolder();
+        $loaderPath = $folder . '/baselines/loader.neon';
+
+        // First, create an existing baseline with errors in specific order: C, A, B
+        $existingBaseline = <<<'NEON'
+parameters:
+    ignoreErrors:
+        -
+            message: '#^Error C$#'
+            count: 1
+            path: ../app/c.php
+
+        -
+            message: '#^Error A$#'
+            count: 1
+            path: ../app/a.php
+
+        -
+            message: '#^Error B$#'
+            count: 1
+            path: ../app/b.php
+
+NEON;
+        file_put_contents($folder . '/baselines/test.identifier.neon', $existingBaseline);
+
+        // Now regenerate with the same errors but in different order in the input: A, B, C
+        $inputErrors = [
+            'parameters' => [
+                'ignoreErrors' => [
+                    ['message' => '#^Error A$#', 'count' => 1, 'path' => '../app/a.php', 'identifier' => 'test.identifier'],
+                    ['message' => '#^Error B$#', 'count' => 1, 'path' => '../app/b.php', 'identifier' => 'test.identifier'],
+                    ['message' => '#^Error C$#', 'count' => 1, 'path' => '../app/c.php', 'identifier' => 'test.identifier'],
+                ],
+            ],
+        ];
+        file_put_contents($loaderPath, Neon::encode($inputErrors));
+
+        $splitter = new BaselineSplitter("\t", true);
+        $splitter->split($loaderPath);
+
+        // The output should preserve the original order: C, A, B
+        $result = file_get_contents($folder . '/baselines/test.identifier.neon');
+        self::assertNotFalse($result);
+
+        // Check that C comes before A and A comes before B in the output
+        $posC = strpos($result, 'Error C');
+        $posA = strpos($result, 'Error A');
+        $posB = strpos($result, 'Error B');
+
+        self::assertNotFalse($posC);
+        self::assertNotFalse($posA);
+        self::assertNotFalse($posB);
+        self::assertLessThan($posA, $posC, 'Error C should come before Error A');
+        self::assertLessThan($posB, $posA, 'Error A should come before Error B');
+    }
+
+    public function testNewErrorsInsertedInSortedPosition(): void
+    {
+        $folder = $this->prepareSampleFolder();
+        $loaderPath = $folder . '/baselines/loader.neon';
+
+        // Create existing baseline with errors for a.php and c.php
+        $existingBaseline = <<<'NEON'
+parameters:
+    ignoreErrors:
+        -
+            message: '#^Error A$#'
+            count: 1
+            path: ../app/a.php
+
+        -
+            message: '#^Error C$#'
+            count: 1
+            path: ../app/c.php
+
+NEON;
+        file_put_contents($folder . '/baselines/test.identifier.neon', $existingBaseline);
+
+        // Now regenerate with an additional error for b.php (new error)
+        $inputErrors = [
+            'parameters' => [
+                'ignoreErrors' => [
+                    ['message' => '#^Error A$#', 'count' => 1, 'path' => '../app/a.php', 'identifier' => 'test.identifier'],
+                    ['message' => '#^Error B$#', 'count' => 1, 'path' => '../app/b.php', 'identifier' => 'test.identifier'],
+                    ['message' => '#^Error C$#', 'count' => 1, 'path' => '../app/c.php', 'identifier' => 'test.identifier'],
+                ],
+            ],
+        ];
+        file_put_contents($loaderPath, Neon::encode($inputErrors));
+
+        $splitter = new BaselineSplitter("\t", true);
+        $splitter->split($loaderPath);
+
+        // The new error B should be inserted between A and C (sorted by path)
+        $result = file_get_contents($folder . '/baselines/test.identifier.neon');
+        self::assertNotFalse($result);
+
+        $posA = strpos($result, 'Error A');
+        $posB = strpos($result, 'Error B');
+        $posC = strpos($result, 'Error C');
+
+        self::assertNotFalse($posA);
+        self::assertNotFalse($posB);
+        self::assertNotFalse($posC);
+        self::assertLessThan($posB, $posA, 'Error A should come before Error B');
+        self::assertLessThan($posC, $posB, 'Error B should come before Error C');
+    }
+
+    public function testRemovedErrorsAreDeleted(): void
+    {
+        $folder = $this->prepareSampleFolder();
+        $loaderPath = $folder . '/baselines/loader.neon';
+
+        // Create existing baseline with errors A, B, C
+        $existingBaseline = <<<'NEON'
+parameters:
+    ignoreErrors:
+        -
+            message: '#^Error A$#'
+            count: 1
+            path: ../app/a.php
+
+        -
+            message: '#^Error B$#'
+            count: 1
+            path: ../app/b.php
+
+        -
+            message: '#^Error C$#'
+            count: 1
+            path: ../app/c.php
+
+NEON;
+        file_put_contents($folder . '/baselines/test.identifier.neon', $existingBaseline);
+
+        // Regenerate with only A and C (B is removed)
+        $inputErrors = [
+            'parameters' => [
+                'ignoreErrors' => [
+                    ['message' => '#^Error A$#', 'count' => 1, 'path' => '../app/a.php', 'identifier' => 'test.identifier'],
+                    ['message' => '#^Error C$#', 'count' => 1, 'path' => '../app/c.php', 'identifier' => 'test.identifier'],
+                ],
+            ],
+        ];
+        file_put_contents($loaderPath, Neon::encode($inputErrors));
+
+        $splitter = new BaselineSplitter("\t", true);
+        $splitter->split($loaderPath);
+
+        $result = file_get_contents($folder . '/baselines/test.identifier.neon');
+        self::assertNotFalse($result);
+
+        // Error B should be removed
+        self::assertStringNotContainsString('Error B', $result);
+        // A and C should still be present in original order
+        self::assertStringContainsString('Error A', $result);
+        self::assertStringContainsString('Error C', $result);
+    }
+
+    public function testCountChangesPreserveOrder(): void
+    {
+        $folder = $this->prepareSampleFolder();
+        $loaderPath = $folder . '/baselines/loader.neon';
+
+        // Create existing baseline with count=2
+        $existingBaseline = <<<'NEON'
+parameters:
+    ignoreErrors:
+        -
+            message: '#^Error A$#'
+            count: 2
+            path: ../app/a.php
+
+NEON;
+        file_put_contents($folder . '/baselines/test.identifier.neon', $existingBaseline);
+
+        // Regenerate with count=5
+        $inputErrors = [
+            'parameters' => [
+                'ignoreErrors' => [
+                    ['message' => '#^Error A$#', 'count' => 5, 'path' => '../app/a.php', 'identifier' => 'test.identifier'],
+                ],
+            ],
+        ];
+        file_put_contents($loaderPath, Neon::encode($inputErrors));
+
+        $splitter = new BaselineSplitter("\t", true);
+        $splitter->split($loaderPath);
+
+        $result = file_get_contents($folder . '/baselines/test.identifier.neon');
+        self::assertNotFalse($result);
+
+        // Count should be updated to 5
+        self::assertStringContainsString('count: 5', $result);
+        self::assertStringNotContainsString('count: 2', $result);
+    }
+
+    public function testFirstRunCreatesFileSorted(): void
+    {
+        $folder = $this->prepareSampleFolder();
+        $loaderPath = $folder . '/baselines/loader.neon';
+
+        // No existing baseline file - first run with errors in unsorted order: C, A, B
+        $inputErrors = [
+            'parameters' => [
+                'ignoreErrors' => [
+                    ['message' => '#^Error C$#', 'count' => 1, 'path' => '../app/c.php', 'identifier' => 'test.identifier'],
+                    ['message' => '#^Error A$#', 'count' => 1, 'path' => '../app/a.php', 'identifier' => 'test.identifier'],
+                    ['message' => '#^Error B$#', 'count' => 1, 'path' => '../app/b.php', 'identifier' => 'test.identifier'],
+                ],
+            ],
+        ];
+        file_put_contents($loaderPath, Neon::encode($inputErrors));
+
+        $splitter = new BaselineSplitter("\t", true);
+        $splitter->split($loaderPath);
+
+        // On first run (no existing file), errors should be written as-is (not sorted by default)
+        // since there's no existing order to preserve
+        $result = file_get_contents($folder . '/baselines/test.identifier.neon');
+        self::assertNotFalse($result);
+
+        self::assertStringContainsString('Error A', $result);
+        self::assertStringContainsString('Error B', $result);
+        self::assertStringContainsString('Error C', $result);
     }
 
     /**


### PR DESCRIPTION
## Summary

- Preserve the order of existing errors when regenerating baseline files to minimize diffs in version control
- Match errors by message+path (ignoring count changes) to identify existing vs new errors
- Insert new errors at sorted positions (by path, then message) for consistent placement
- Remove errors that no longer exist in the new baseline

## Motivation

When regenerating baselines, the previous behavior would write errors in whatever order PHPStan outputted them. This could cause large diffs even when only a few errors actually changed, making code reviews harder.

With this change, errors that existed before will stay in the same positions in the file, so only actual changes (new errors, removed errors, count updates) will appear in the diff.

## Test plan

- [x] Added tests for order preservation (`testPreservesOrderOfExistingErrors`)
- [x] Added tests for new error insertion (`testNewErrorsInsertedInSortedPosition`)
- [x] Added tests for error removal (`testRemovedErrorsAreDeleted`)
- [x] Added tests for count updates (`testCountChangesPreserveOrder`)
- [x] Added tests for first run behavior (`testFirstRunCreatesFileSorted`)
- [x] All existing tests pass
- [x] PHPStan passes
- [x] Coding style passes