### PR TITLE
Automatically delete orphaned baseline files

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,6 @@ _(optional)_ You can simplify generation with e.g. composer script:
     "scripts": {
         "generate:baseline:phpstan": [
             "phpstan --generate-baseline=baselines/_loader.neon",
-            "find baselines/ -type f -not -name _loader.neon -delete",
             "split-phpstan-baseline baselines/_loader.neon"
         ]
     }

--- a/bin/split-phpstan-baseline
+++ b/bin/split-phpstan-baseline
@@ -56,7 +56,13 @@ try {
     $writtenBaselines = $splitter->split($loaderFile);
 
     foreach ($writtenBaselines as $writtenBaseline => $errorsCount) {
-        echo "Writing baseline file $writtenBaseline" . ($errorsCount !== null ? " with $errorsCount errors\n" : "\n");
+        if ($errorsCount === 0) {
+            echo "Deleting baseline file $writtenBaseline\n";
+        } elseif ($errorsCount !== null) {
+            echo "Writing baseline file $writtenBaseline with $errorsCount errors\n";
+        } else {
+            echo "Writing baseline file $writtenBaseline\n";
+        }
     }
 
 } catch (ErrorException $e) {

--- a/src/BaselineSplitter.php
+++ b/src/BaselineSplitter.php
@@ -8,11 +8,14 @@ use ShipMonk\PHPStan\Baseline\Handler\BaselineHandler;
 use ShipMonk\PHPStan\Baseline\Handler\HandlerFactory;
 use SplFileInfo;
 use function array_reduce;
+use function basename;
 use function dirname;
 use function file_put_contents;
+use function glob;
 use function is_file;
 use function ksort;
 use function str_replace;
+use function unlink;
 
 class BaselineSplitter
 {
@@ -31,7 +34,7 @@ class BaselineSplitter
     }
 
     /**
-     * @return array<string, int|null>
+     * @return array<string, int|null> file path => error count (null for loader, 0 for deleted)
      *
      * @throws ErrorException
      */
@@ -45,6 +48,7 @@ class BaselineSplitter
         }
 
         $folder = dirname($realPath);
+        $loaderFileName = $splFile->getFilename();
         $extension = $splFile->getExtension();
 
         $handler = HandlerFactory::create($extension);
@@ -53,6 +57,7 @@ class BaselineSplitter
 
         $outputInfo = [];
         $baselineFiles = [];
+        $writtenFiles = [];
         $totalErrorCount = 0;
 
         foreach ($groupedErrors as $identifier => $newErrors) {
@@ -67,6 +72,7 @@ class BaselineSplitter
 
             $outputInfo[$filePath] = $errorsCount;
             $baselineFiles[] = $fileName;
+            $writtenFiles[$filePath] = true;
 
             $plural = $errorsCount === 1 ? '' : 's';
             $prefix = $this->includeCount ? "total $errorsCount error$plural" : null;
@@ -81,6 +87,13 @@ class BaselineSplitter
         $this->writeFile($realPath, $baselineLoaderData);
 
         $outputInfo[$realPath] = null;
+
+        // Delete orphaned baseline files
+        $deletedFiles = $this->deleteOrphanedFiles($folder, $extension, $loaderFileName, $writtenFiles);
+
+        foreach ($deletedFiles as $deletedFile) {
+            $outputInfo[$deletedFile] = 0;
+        }
 
         return $outputInfo;
     }
@@ -218,6 +231,46 @@ class BaselineSplitter
         }
 
         return $result;
+    }
+
+    /**
+     * @param array<string, true> $writtenFiles
+     * @return list<string>
+     */
+    private function deleteOrphanedFiles(
+        string $folder,
+        string $extension,
+        string $loaderFileName,
+        array $writtenFiles
+    ): array
+    {
+        $deletedFiles = [];
+        $existingFiles = glob($folder . '/*.' . $extension);
+
+        if ($existingFiles === false) {
+            return [];
+        }
+
+        foreach ($existingFiles as $existingFile) {
+            $fileName = basename($existingFile);
+
+            // Skip the loader file
+            if ($fileName === $loaderFileName) {
+                continue;
+            }
+
+            // Skip files that were written in this run
+            if (isset($writtenFiles[$existingFile])) {
+                continue;
+            }
+
+            // Delete orphaned file
+            if (unlink($existingFile)) {
+                $deletedFiles[] = $existingFile;
+            }
+        }
+
+        return $deletedFiles;
     }
 
 }

--- a/tests/SplitterTest.php
+++ b/tests/SplitterTest.php
@@ -334,6 +334,138 @@ NEON;
         self::assertStringContainsString('Error C', $result);
     }
 
+    public function testOrphanedFilesAreDeleted(): void
+    {
+        $folder = $this->prepareSampleFolder();
+        $loaderPath = $folder . '/baselines/loader.neon';
+
+        // Create existing baseline files for two identifiers
+        $existingBaseline1 = <<<'NEON'
+parameters:
+    ignoreErrors:
+        -
+            message: '#^Error A$#'
+            count: 1
+            path: ../app/a.php
+
+NEON;
+        $existingBaseline2 = <<<'NEON'
+parameters:
+    ignoreErrors:
+        -
+            message: '#^Error B$#'
+            count: 1
+            path: ../app/b.php
+
+NEON;
+        file_put_contents($folder . '/baselines/first.identifier.neon', $existingBaseline1);
+        file_put_contents($folder . '/baselines/second.identifier.neon', $existingBaseline2);
+
+        // Now regenerate with only first.identifier (second.identifier should be deleted)
+        $inputErrors = [
+            'parameters' => [
+                'ignoreErrors' => [
+                    ['message' => '#^Error A$#', 'count' => 1, 'path' => '../app/a.php', 'identifier' => 'first.identifier'],
+                ],
+            ],
+        ];
+        file_put_contents($loaderPath, Neon::encode($inputErrors));
+
+        $splitter = new BaselineSplitter("\t", true);
+        $result = $splitter->split($loaderPath);
+
+        $firstIdentifierPath = $folder . '/baselines/first.identifier.neon';
+        $secondIdentifierPath = $folder . '/baselines/second.identifier.neon';
+
+        // first.identifier.neon should still exist
+        self::assertFileExists($firstIdentifierPath);
+        self::assertArrayHasKey($firstIdentifierPath, $result);
+        self::assertSame(1, $result[$firstIdentifierPath]);
+
+        // second.identifier.neon should be deleted
+        self::assertFileDoesNotExist($secondIdentifierPath);
+        self::assertArrayHasKey($secondIdentifierPath, $result);
+        self::assertSame(0, $result[$secondIdentifierPath]);
+
+        // loader should still exist
+        self::assertFileExists($loaderPath);
+        self::assertArrayHasKey($loaderPath, $result);
+        self::assertNull($result[$loaderPath]);
+    }
+
+    public function testLoaderFileIsNotDeleted(): void
+    {
+        $folder = $this->prepareSampleFolder();
+        $loaderPath = $folder . '/baselines/loader.neon';
+        $orphanPath = $folder . '/baselines/orphan.neon';
+
+        // Create an empty baseline (no errors)
+        $inputErrors = [
+            'parameters' => [
+                'ignoreErrors' => [],
+            ],
+        ];
+        file_put_contents($loaderPath, Neon::encode($inputErrors));
+
+        // Create an orphaned file that happens to exist
+        file_put_contents($orphanPath, 'some content');
+
+        $splitter = new BaselineSplitter("\t", true);
+        $result = $splitter->split($loaderPath);
+
+        // Loader should still exist
+        self::assertFileExists($loaderPath);
+        self::assertArrayHasKey($loaderPath, $result);
+        self::assertNull($result[$loaderPath]);
+
+        // Orphaned file should be deleted
+        self::assertFileDoesNotExist($orphanPath);
+        self::assertArrayHasKey($orphanPath, $result);
+        self::assertSame(0, $result[$orphanPath]);
+    }
+
+    public function testOnlyFilesWithMatchingExtensionAreDeleted(): void
+    {
+        $folder = $this->prepareSampleFolder();
+        $loaderPath = $folder . '/baselines/loader.neon';
+
+        // Create a .neon baseline file and a .php file
+        $existingBaseline = <<<'NEON'
+parameters:
+    ignoreErrors:
+        -
+            message: '#^Error A$#'
+            count: 1
+            path: ../app/a.php
+
+NEON;
+        file_put_contents($folder . '/baselines/old.identifier.neon', $existingBaseline);
+        file_put_contents($folder . '/baselines/some.file.php', '<?php // some php file');
+
+        // Regenerate with empty baseline
+        $inputErrors = [
+            'parameters' => [
+                'ignoreErrors' => [],
+            ],
+        ];
+        file_put_contents($loaderPath, Neon::encode($inputErrors));
+
+        $splitter = new BaselineSplitter("\t", true);
+        $result = $splitter->split($loaderPath);
+
+        $oldIdentifierPath = $folder . '/baselines/old.identifier.neon';
+        $phpFilePath = $folder . '/baselines/some.file.php';
+
+        // .neon file should be deleted
+        self::assertFileDoesNotExist($oldIdentifierPath);
+        self::assertArrayHasKey($oldIdentifierPath, $result);
+        self::assertSame(0, $result[$oldIdentifierPath]);
+
+        // .php file should NOT be deleted (wrong extension)
+        self::assertFileExists($phpFilePath);
+        self::assertArrayNotHasKey($phpFilePath, $result);
+    }
+
     /**
      * @return array{parameters: array{ignoreErrors: array{0: array{message?: string, rawMessage?: string, count: int, path: string, identifier?: string}}}}
      */


### PR DESCRIPTION
## Summary

- The `split-phpstan-baseline` command now automatically deletes baseline files that no longer have corresponding errors
- This eliminates the need for the manual `find baselines/ -type f -not -name _loader.neon -delete` step
- The deletion is extension-aware: only files with the same extension as the loader are deleted

## Test plan

- [x] Added `testOrphanedFilesAreDeleted` - verifies baseline files for removed identifiers are deleted
- [x] Added `testLoaderFileIsNotDeleted` - verifies the loader file is never deleted
- [x] Added `testOnlyFilesWithMatchingExtensionAreDeleted` - verifies only matching extensions are deleted
- [x] All existing tests pass
- [x] PHPStan analysis passes
- [x] Coding standards pass