### PR TITLE
Bump phpunit/phpunit to fix CVE-2026-24765

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "shipmonk/composer-dependency-analyser": "1.8.3",
         "shipmonk/dead-code-detector": "^0.11.0",
         "shipmonk/name-collision-detector": "2.1.1",
-        "shipmonk/phpstan-rules": "4.1.2"
+        "shipmonk/phpstan-rules": "4.3.5"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "ergebnis/composer-normalize": "^2.45",
         "phpstan/phpstan-phpunit": "2.0.6",
         "phpstan/phpstan-strict-rules": "2.0.4",
-        "phpunit/phpunit": "9.6.23",
+        "phpunit/phpunit": "^9.6.33",
         "shipmonk/coding-standard": "^0.2.0",
         "shipmonk/composer-dependency-analyser": "1.8.3",
         "shipmonk/dead-code-detector": "^0.11.0",


### PR DESCRIPTION
## Summary
- Bumps `phpunit/phpunit` from `9.6.23` to `^9.6.33` to fix [CVE-2026-24765](https://github.com/advisories/GHSA-vvj3-c3rp-c85p) (unsafe deserialization in PHPT code coverage handling, CVSS 7.8 High)