### PR TITLE
Upgrade shipmonk/dead-code-detector to ^1.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "phpunit/phpunit": "^9.6.33",
         "shipmonk/coding-standard": "^0.2.0",
         "shipmonk/composer-dependency-analyser": "1.8.3",
-        "shipmonk/dead-code-detector": "^0.11.0",
+        "shipmonk/dead-code-detector": "^1.0",
         "shipmonk/name-collision-detector": "2.1.1",
         "shipmonk/phpstan-rules": "4.3.5"
     },

--- a/src/BaselineSplitter.php
+++ b/src/BaselineSplitter.php
@@ -101,8 +101,6 @@ class BaselineSplitter
     /**
      * @param list<array{message: string, count: int, path: string, identifier: string|null}|array{rawMessage: string, count: int, path: string, identifier: string|null}> $errors
      * @return array<string, list<array{message: string, count: int, path: string}|array{rawMessage: string, count: int, path: string}>>
-     *
-     * @throws ErrorException
      */
     private function groupErrorsByIdentifier(
         array $errors,
@@ -122,15 +120,12 @@ class BaselineSplitter
                     'path' => $normalizedPath,
                 ];
 
-            } elseif (isset($error['message'])) {
+            } else {
                 $groupedErrors[$identifier][] = [
                     'message' => $error['message'],
                     'count' => $error['count'],
                     'path' => $normalizedPath,
                 ];
-
-            } else {
-                throw new ErrorException('Error is missing message or rawMessage');
             }
         }
 

--- a/src/Handler/PhpBaselineHandler.php
+++ b/src/Handler/PhpBaselineHandler.php
@@ -51,7 +51,7 @@ class PhpBaselineHandler extends BaselineHandler
                 $message = $error['rawMessage'];
                 $messageKey = 'rawMessage';
             } else {
-                $message = $error['message']; // @phpstan-ignore offsetAccess.notFound
+                $message = $error['message'];
                 $messageKey = 'message';
             }
 


### PR DESCRIPTION
## Summary
- Upgrade `shipmonk/dead-code-detector` from `^0.11.0` to `^1.0`
- Fix PHPStan errors surfaced by phpstan upgrade (remove stale `@throws`, `isset` check, and `@phpstan-ignore`)

Co-Authored-By: Claude Code