### PR TITLE
Drop PHP 7.4 and 8.0 support, modernize to PHP 8.1+

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -32,7 +32,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                php-version: [ '7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5' ]
+                php-version: [ '8.1', '8.2', '8.3', '8.4', '8.5' ]
                 dependency-version: [ prefer-lowest, prefer-stable ]
         steps:
             -

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "error identifier"
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "nette/neon": "^3.3.3 || ^4.0",
         "phpstan/phpstan": "^2"
     },

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -11,16 +11,10 @@
 
     <exclude-pattern>tests/*/data/*</exclude-pattern>
 
-    <config name="php_version" value="70400"/>
+    <config name="php_version" value="80100"/>
     <config name="installed_paths" value="vendor/slevomat/coding-standard,vendor/shipmonk/coding-standard"/>
 
     <rule ref="ShipMonkCodingStandard">
         <exclude name="SlevomatCodingStandard.Commenting.ForbiddenAnnotations.AnnotationForbidden"/><!-- It removes @dataProvider, but PHPUnit 9 does not yet have #[DataProvider] -->
-    </rule>
-
-    <rule ref="SlevomatCodingStandard.Functions.DisallowTrailingCommaInDeclaration">
-        <properties>
-            <property name="onlySingleLine" value="false"/>
-        </properties>
     </rule>
 </ruleset>

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -9,7 +9,7 @@ includes:
     - ./extension.neon
 
 parameters:
-    phpVersion: 80000
+    phpVersion: 80100
     paths:
         - bin/split-phpstan-baseline
         - src

--- a/src/BaselinePerIdentifierFormatter.php
+++ b/src/BaselinePerIdentifierFormatter.php
@@ -25,13 +25,11 @@ use const SORT_STRING;
 class BaselinePerIdentifierFormatter implements ErrorFormatter
 {
 
-    private string $baselinesDir;
-
-    private string $indent;
+    private readonly string $baselinesDir;
 
     public function __construct(
         ?string $baselinesDir,
-        string $indent
+        private readonly string $indent,
     )
     {
         if ($baselinesDir === null) {
@@ -45,12 +43,11 @@ class BaselinePerIdentifierFormatter implements ErrorFormatter
         }
 
         $this->baselinesDir = $baselinesRealDir;
-        $this->indent = $indent;
     }
 
     public function formatErrors(
         AnalysisResult $analysisResult,
-        Output $output
+        Output $output,
     ): int
     {
         foreach ($analysisResult->getInternalErrorObjects() as $internalError) {
@@ -138,7 +135,7 @@ class BaselinePerIdentifierFormatter implements ErrorFormatter
 
     private function getPathDifference(
         string $from,
-        string $to
+        string $to,
     ): string
     {
         $fromParts = explode(DIRECTORY_SEPARATOR, $from);

--- a/src/BaselineSplitter.php
+++ b/src/BaselineSplitter.php
@@ -95,6 +95,9 @@ class BaselineSplitter
     /**
      * @param list<array{message: string, count: int, path: string, identifier: string|null}|array{rawMessage: string, count: int, path: string, identifier: string|null}> $errors
      * @return array<string, list<array{message: string, count: int, path: string}|array{rawMessage: string, count: int, path: string}>>
+     *
+     * @throws ErrorException
+     * @phpstan-ignore throws.unusedType
      */
     private function groupErrorsByIdentifier(
         array $errors,
@@ -114,12 +117,15 @@ class BaselineSplitter
                     'path' => $normalizedPath,
                 ];
 
-            } else {
+            } elseif (isset($error['message'])) { // @phpstan-ignore isset.offset
                 $groupedErrors[$identifier][] = [
                     'message' => $error['message'],
                     'count' => $error['count'],
                     'path' => $normalizedPath,
                 ];
+
+            } else {
+                throw new ErrorException('Error is missing message or rawMessage');
             }
         }
 

--- a/src/BaselineSplitter.php
+++ b/src/BaselineSplitter.php
@@ -20,17 +20,11 @@ use function unlink;
 class BaselineSplitter
 {
 
-    private string $indent;
-
-    private bool $includeCount;
-
     public function __construct(
-        string $indent,
-        bool $includeCount
+        private readonly string $indent,
+        private readonly bool $includeCount,
     )
     {
-        $this->indent = $indent;
-        $this->includeCount = $includeCount;
     }
 
     /**
@@ -101,12 +95,10 @@ class BaselineSplitter
     /**
      * @param list<array{message: string, count: int, path: string, identifier: string|null}|array{rawMessage: string, count: int, path: string, identifier: string|null}> $errors
      * @return array<string, list<array{message: string, count: int, path: string}|array{rawMessage: string, count: int, path: string}>>
-     *
-     * @throws ErrorException
      */
     private function groupErrorsByIdentifier(
         array $errors,
-        string $folder
+        string $folder,
     ): array
     {
         $groupedErrors = [];
@@ -122,15 +114,12 @@ class BaselineSplitter
                     'path' => $normalizedPath,
                 ];
 
-            } elseif (isset($error['message'])) {
+            } else {
                 $groupedErrors[$identifier][] = [
                     'message' => $error['message'],
                     'count' => $error['count'],
                     'path' => $normalizedPath,
                 ];
-
-            } else {
-                throw new ErrorException('Error is missing message or rawMessage');
             }
         }
 
@@ -144,7 +133,7 @@ class BaselineSplitter
      */
     private function writeFile(
         string $filePath,
-        string $contents
+        string $contents,
     ): void
     {
         $written = file_put_contents($filePath, $contents);
@@ -167,7 +156,7 @@ class BaselineSplitter
      */
     private function readExistingErrors(
         string $filePath,
-        BaselineHandler $handler
+        BaselineHandler $handler,
     ): ?array
     {
         if (!is_file($filePath)) {
@@ -189,7 +178,7 @@ class BaselineSplitter
      */
     private function sortErrors(
         array $oldErrors,
-        array $newErrors
+        array $newErrors,
     ): array
     {
         $newErrorsByKey = [];
@@ -241,7 +230,7 @@ class BaselineSplitter
         string $folder,
         string $extension,
         string $loaderFileName,
-        array $writtenFiles
+        array $writtenFiles,
     ): array
     {
         $deletedFiles = [];

--- a/src/BaselineSplitter.php
+++ b/src/BaselineSplitter.php
@@ -95,9 +95,6 @@ class BaselineSplitter
     /**
      * @param list<array{message: string, count: int, path: string, identifier: string|null}|array{rawMessage: string, count: int, path: string, identifier: string|null}> $errors
      * @return array<string, list<array{message: string, count: int, path: string}|array{rawMessage: string, count: int, path: string}>>
-     *
-     * @throws ErrorException
-     * @phpstan-ignore throws.unusedType
      */
     private function groupErrorsByIdentifier(
         array $errors,
@@ -117,15 +114,12 @@ class BaselineSplitter
                     'path' => $normalizedPath,
                 ];
 
-            } elseif (isset($error['message'])) { // @phpstan-ignore isset.offset
+            } else {
                 $groupedErrors[$identifier][] = [
                     'message' => $error['message'],
                     'count' => $error['count'],
                     'path' => $normalizedPath,
                 ];
-
-            } else {
-                throw new ErrorException('Error is missing message or rawMessage');
             }
         }
 

--- a/src/Exception/ErrorException.php
+++ b/src/Exception/ErrorException.php
@@ -10,7 +10,7 @@ class ErrorException extends RuntimeException
 
     public function __construct(
         string $message,
-        ?Throwable $previous = null
+        ?Throwable $previous = null,
     )
     {
         parent::__construct($message, 0, $previous);

--- a/src/Handler/BaselineHandler.php
+++ b/src/Handler/BaselineHandler.php
@@ -94,7 +94,7 @@ abstract class BaselineHandler
     abstract public function encodeBaseline(
         ?string $comment,
         array $errors,
-        string $indent
+        string $indent,
     ): string;
 
     /**
@@ -103,7 +103,7 @@ abstract class BaselineHandler
     abstract public function encodeBaselineLoader(
         ?string $comment,
         array $filePaths,
-        string $indent
+        string $indent,
     ): string;
 
 }

--- a/src/Handler/HandlerFactory.php
+++ b/src/Handler/HandlerFactory.php
@@ -12,16 +12,11 @@ class HandlerFactory
      */
     public static function create(string $extension): BaselineHandler
     {
-        switch ($extension) {
-            case 'neon':
-                return new NeonBaselineHandler();
-
-            case 'php':
-                return new PhpBaselineHandler();
-
-            default:
-                throw new ErrorException("Invalid baseline file extension '$extension', expected neon or php file");
-        }
+        return match ($extension) {
+            'neon' => new NeonBaselineHandler(),
+            'php' => new PhpBaselineHandler(),
+            default => throw new ErrorException("Invalid baseline file extension '$extension', expected neon or php file"),
+        };
     }
 
 }

--- a/src/Handler/NeonBaselineHandler.php
+++ b/src/Handler/NeonBaselineHandler.php
@@ -32,7 +32,7 @@ class NeonBaselineHandler extends BaselineHandler
     public function encodeBaseline(
         ?string $comment,
         array $errors,
-        string $indent
+        string $indent,
     ): string
     {
         $prefix = $comment !== null ? "# $comment\n\n" : '';
@@ -42,7 +42,7 @@ class NeonBaselineHandler extends BaselineHandler
     public function encodeBaselineLoader(
         ?string $comment,
         array $filePaths,
-        string $indent
+        string $indent,
     ): string
     {
         $prefix = $comment !== null ? "# $comment\n\n" : '';

--- a/src/Handler/PhpBaselineHandler.php
+++ b/src/Handler/PhpBaselineHandler.php
@@ -33,7 +33,7 @@ class PhpBaselineHandler extends BaselineHandler
     public function encodeBaseline(
         ?string $comment,
         array $errors,
-        string $indent
+        string $indent,
     ): string
     {
         $php = '<?php declare(strict_types = 1);';
@@ -51,7 +51,7 @@ class PhpBaselineHandler extends BaselineHandler
                 $message = $error['rawMessage'];
                 $messageKey = 'rawMessage';
             } else {
-                $message = $error['message']; // @phpstan-ignore offsetAccess.notFound
+                $message = $error['message'];
                 $messageKey = 'message';
             }
 
@@ -74,7 +74,7 @@ class PhpBaselineHandler extends BaselineHandler
     public function encodeBaselineLoader(
         ?string $comment,
         array $filePaths,
-        string $indent
+        string $indent,
     ): string
     {
         $php = "<?php declare(strict_types = 1);\n\n";

--- a/src/NeonHelper.php
+++ b/src/NeonHelper.php
@@ -10,12 +10,9 @@ use function trim;
 class NeonHelper
 {
 
-    /**
-     * @param mixed $data
-     */
     public static function encode(
-        $data,
-        string $indent
+        mixed $data,
+        string $indent,
     ): string
     {
         return trim(Neon::encode($data, true, $indent)) . "\n";

--- a/tests/BinTestCase.php
+++ b/tests/BinTestCase.php
@@ -16,7 +16,7 @@ abstract class BinTestCase extends TestCase
         string $cwd,
         int $expectedExitCode,
         ?string $expectedOutputContains = null,
-        ?string $expectedErrorContains = null
+        ?string $expectedErrorContains = null,
     ): void
     {
         $desc = [

--- a/tests/Integration/IntegrationTest.php
+++ b/tests/Integration/IntegrationTest.php
@@ -17,7 +17,7 @@ final class IntegrationTest extends BinTestCase
      */
     public function testResultCache(
         string $extension,
-        bool $bleedingEdge
+        bool $bleedingEdge,
     ): void
     {
         $emptyConfig = $extension === 'php' ? '<?php return [];' : '';


### PR DESCRIPTION
## Summary

- Bump `composer.json` php constraint from `^7.4 || ^8.0` to `^8.1`
- Drop 7.4 and 8.0 from CI test matrix
- Bump phpcs `php_version` to `80100` (and drop the now-default `DisallowTrailingCommaInDeclaration` override)
- Bump phpstan `phpVersion` to `80100`
- Modernize source code:
    - Promote constructor properties to `readonly`
    - Trailing commas in multi-line function declarations
    - `switch` → `match` in `HandlerFactory`
    - Native `mixed` type in `NeonHelper::encode()`
    - Simplify `BaselineSplitter::groupErrorsByIdentifier()` — drop unreachable branch now that PHPStan correctly infers the union shape
    - Drop now-redundant `@phpstan-ignore offsetAccess.notFound`

Inspired by shipmonk-rnd/phpstan-rules#361 and shipmonk-rnd/dead-code-detector#296.

## Test plan

- [x] `composer check` is green (composer-normalize, phpcs, phpstan, phpunit, collision detector, dep analyser)
- [x] CI matrix passes on 8.1 – 8.5

Co-Authored-By: Claude Code