### PR TITLE
Upgrade shipmonk/dead-code-detector to ^1.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "phpunit/phpunit": "^10.5.46",
         "shipmonk/coding-standard": "^0.2.0",
         "shipmonk/composer-dependency-analyser": "1.8.3",
-        "shipmonk/dead-code-detector": "^0.11.0",
+        "shipmonk/dead-code-detector": "^1.0",
         "shipmonk/name-collision-detector": "2.1.1",
         "shipmonk/phpstan-rules": "4.3.5"
     },


### PR DESCRIPTION
## Summary
- Upgrade `shipmonk/dead-code-detector` from `^0.11.0` to `^1.0`

Revives #57 (the PHPStan error fixes from the original PR are no longer needed — they were already addressed on master as part of the PHP 8.1+ modernization in #59).

Co-Authored-By: Claude Code