### PR TITLE
Fix PHPStan 2.2 sealed array shape violations

### DIFF
--- a/src/BaselineSplitter.php
+++ b/src/BaselineSplitter.php
@@ -164,11 +164,20 @@ class BaselineSplitter
         }
 
         try {
-            return $handler->decodeBaseline($filePath);
+            $decoded = $handler->decodeBaseline($filePath);
 
         } catch (ErrorException $e) {
             return null;
         }
+
+        $errors = [];
+
+        foreach ($decoded as $error) {
+            unset($error['identifier']);
+            $errors[] = $error;
+        }
+
+        return $errors;
     }
 
     /**

--- a/tests/SplitterTest.php
+++ b/tests/SplitterTest.php
@@ -467,7 +467,7 @@ NEON;
     }
 
     /**
-     * @return array{parameters: array{ignoreErrors: array{0: array{message?: string, rawMessage?: string, count: int, path: string, identifier?: string}}}}
+     * @return array{parameters: array{ignoreErrors: list<array{message?: string, rawMessage?: string, count: int, path: string, identifier?: string}>}}
      */
     private function getSampleErrors(): array
     {


### PR DESCRIPTION
## Summary
- PHPStan 2.2 enforces sealed array shapes more strictly, surfacing two pre-existing type mismatches.
- `readExistingErrors()` declared a return type without `identifier`, but delegated to `decodeBaseline()` which always sets it. Strip the key so runtime matches the declared shape (the field isn't used downstream).
- `SplitterTest::getSampleErrors()` declared `ignoreErrors` as `array{0: ...}` (sealed, single index) but returned 4 entries — switched to `list<...>`.

## Test plan
- [x] `composer check:types` passes on PHPStan 2.2.0
- [x] `composer check:tests` — all 18 tests / 230 assertions still pass
- [x] full `composer check` suite green

Co-Authored-By: Claude Code